### PR TITLE
Avoid size-allocating invisible widgets

### DIFF
--- a/src/gtk/win_gtk.cpp
+++ b/src/gtk/win_gtk.cpp
@@ -454,6 +454,9 @@ struct AdjustData {
 extern "C" {
 static void scroll_adjust(GtkWidget* widget, void* data)
 {
+    if(!gtk_widget_get_visible(widget))
+        return;
+
     const AdjustData* p = static_cast<AdjustData*>(data);
     GtkAllocation a;
     gtk_widget_get_allocation(widget, &a);


### PR DESCRIPTION
Avoids Gtk-CRITICAL gtk_widget_set_allocation: assertion '_gtk_widget_get_visible (widget) || _gtk_widget_is_toplevel (widget)' failed

Previously fixed upstream.

Picked from: https://github.com/wxWidgets/wxWidgets/commit/54ed3ab

This will fix the remaining Gtk-CRITICAL assertions in OrcaSlicer, along with https://github.com/OrcaSlicer/OrcaSlicer/pull/11897